### PR TITLE
Improve get responses

### DIFF
--- a/R/get_responses.R
+++ b/R/get_responses.R
@@ -13,7 +13,7 @@
 #' get_responses(12345)
 #' }
 
-get_responses <- function(iSurveyID, sDocumentType = "csv", sLanguageCode = "en",
+get_responses <- function(iSurveyID, sDocumentType = "csv", sLanguageCode = NULL,
                           sCompletionStatus = "complete", sHeadingType = "code",
                           sResponseType = "long", ...) {
   # Put all the function's arguments in a list to then be passed to call_limer()

--- a/R/get_responses.R
+++ b/R/get_responses.R
@@ -18,6 +18,9 @@ get_responses <- function(iSurveyID, sDocumentType = "csv", sLanguageCode = "en"
                           sResponseType = "long", ...) {
   # Put all the function's arguments in a list to then be passed to call_limer()
   params <- as.list(environment())
+  dots <- list(...)
+  if(length(dots) > 0) params <- append(params,dots)
+  # print(params) # uncomment to debug the params
 
   results <- call_limer(method = "export_responses", params = params)
   return(base64_to_df(unlist(results)))

--- a/man/get_responses.Rd
+++ b/man/get_responses.Rd
@@ -4,7 +4,7 @@
 \alias{get_responses}
 \title{Export data from a LimeSurvey survey}
 \usage{
-get_responses(iSurveyID, sDocumentType = "csv", sLanguageCode = "en",
+get_responses(iSurveyID, sDocumentType = "csv", sLanguageCode = NULL,
   sCompletionStatus = "complete", sHeadingType = "code",
   sResponseType = "long", ...)
 }


### PR DESCRIPTION
@andrewheiss 
I made up some improvements for get_responses.

First improvement is that '...' (dots or ellipsis) is not in R's environment, so the 7th argument of get_responses() does not do anything. We will have to add it. Tested in R 3.3.0. Background: we wanted to use iFromResponseID and iToResponseID:
https://github.com/LimeSurvey/LimeSurvey/blob/master/application/helpers/remotecontrol/remotecontrol_handle.php#L2433
There was no way to do that with get_responses() in limer.

Second improvement is to remove the default 'en' language. My business partner had a hard time to understand why he did not get results with sLanguageCode = 'nl', until I told him it had to be sLanguageCode = 'nl-informal'. By changing the default from 'en' to NULL, Limesurvey uses getBaseLanguageFromSurveyID to get the languge:
https://github.com/LimeSurvey/LimeSurvey/blob/master/application/helpers/remotecontrol/remotecontrol_handle.php#L2447
There is a tiny chance that this may break current implementations: when a LS-user has a survey with, for instance, 'nl' as base languge and 'en' as second language a call to get_responses without a value for sLanguageCode will not get the 'en' results anymore.

Please review and merge the PR