### PR TITLE
Prefix POST with httr package

### DIFF
--- a/R/call_limer.R
+++ b/R/call_limer.R
@@ -33,7 +33,7 @@ call_limer <- function(method, params = list(), ...) {
                     id = " ",
                     params = params.full)
 
-  r <- POST(getOption('lime_api'), content_type_json(),
+  r <- httr::POST(getOption('lime_api'), content_type_json(),
             body = jsonlite::toJSON(body.json, auto_unbox = TRUE), ...)
 
   return(jsonlite::fromJSON(content(r, as='text', encoding="utf-8"))$result)   # incorporated fix by petrbouchal


### PR DESCRIPTION
Prefix the `POST` in the `call_limer` function with the httr package.
Otherwise, it is necessary to load the httr library.