### PR TITLE
Prefix functions in call_limer with the httr package

### DIFF
--- a/R/call_limer.R
+++ b/R/call_limer.R
@@ -33,8 +33,8 @@ call_limer <- function(method, params = list(), ...) {
                     id = " ",
                     params = params.full)
 
-  r <- httr::POST(getOption('lime_api'), content_type_json(),
+  r <- httr::POST(getOption('lime_api'), httr::content_type_json(),
             body = jsonlite::toJSON(body.json, auto_unbox = TRUE), ...)
 
-  return(jsonlite::fromJSON(content(r, as='text', encoding="utf-8"))$result)   # incorporated fix by petrbouchal
+  return(jsonlite::fromJSON(httr::content(r, as='text', encoding="utf-8"))$result)   # incorporated fix by petrbouchal
 }


### PR DESCRIPTION
Besides `content`, there was the `content_type_json` function remaining without the httr prefix.