### PR TITLE
Update base64_to_df to work with the current version of LimeSurvey (3.x)

### DIFF
--- a/R/base64_to_df.R
+++ b/R/base64_to_df.R
@@ -11,5 +11,5 @@
 base64_to_df <- function(x) {
   raw_csv <- rawToChar(base64enc::base64decode(x))
 
-  return(read.csv(textConnection(raw_csv), stringsAsFactors = FALSE))
+  return(read.csv(textConnection(raw_csv), stringsAsFactors = FALSE, sep = ";")))
 }


### PR DESCRIPTION
Now variables are delimited by `;`, which yielded single-column data.frames previously.