### PR TITLE
Added support for LimeSurvey 2.x

### DIFF
--- a/R/base64_to_df.R
+++ b/R/base64_to_df.R
@@ -8,8 +8,8 @@
 #' base64_to_df()
 #' }
 
-base64_to_df <- function(x) {
+base64_to_df <- function(x, sep=";") {
   raw_csv <- rawToChar(base64enc::base64decode(x))
 
-  return(read.csv(textConnection(raw_csv), stringsAsFactors = FALSE, sep = ";"))
+  return(read.csv(textConnection(raw_csv), stringsAsFactors = FALSE, sep = sep))
 }

--- a/R/get_responses.R
+++ b/R/get_responses.R
@@ -7,6 +7,7 @@
 #' @param sCompletionStatus \dots
 #' @param sHeadingType \dots
 #' @param sResponseType \dots
+#' @param sep \dots
 #' @param \dots Further arguments to \code{\link{call_limer}}.
 #' @export
 #' @examples \dontrun{
@@ -15,7 +16,7 @@
 
 get_responses <- function(iSurveyID, sDocumentType = "csv", sLanguageCode = NULL,
                           sCompletionStatus = "complete", sHeadingType = "code",
-                          sResponseType = "long", ...) {
+                          sResponseType = "long", sep=";", ...) {
   # Put all the function's arguments in a list to then be passed to call_limer()
   params <- as.list(environment())
   dots <- list(...)
@@ -23,5 +24,5 @@ get_responses <- function(iSurveyID, sDocumentType = "csv", sLanguageCode = NULL
   # print(params) # uncomment to debug the params
 
   results <- call_limer(method = "export_responses", params = params)
-  return(base64_to_df(unlist(results)))
+  return(base64_to_df(unlist(results), sep=sep))
 }


### PR DESCRIPTION
As I am still using LimeSurvey 2.x, I added an option to specify the separator in base64_to_df and get_responses to work with 2.x (default is set to ";" for LimeSurvey 3.x).