### PR TITLE
get_participants : set default values for arguments except iSurveyID

### DIFF
--- a/R/get_participants.R
+++ b/R/get_participants.R
@@ -13,10 +13,19 @@
 #' get_participants(12345, iStart=1, iLimit=10, bUnused=FALSE, aAttributes=FALSE)
 #' }
 
-get_participants <- function(iSurveyID, iStart, iLimit, bUnused, aAttributes){
+get_participants <- function(iSurveyID, iStart = 0, iLimit = NULL, bUnused = FALSE, aAttributes = list(), aConditions = list()){
+
+  if (is.null(iLimit)) {
+    iLimit <- limer::call_limer("get_summary", list("iSurveyID" = iSurveyID, "sStatName" = "token_count"))
+    iLimit <- as.integer(iLimit)
+  }
+
   # Put all the function's arguments in a list to then be passed to call_limer()
   params <- as.list(environment())
 
-  results <- call_limer(method = "list_participants", params = params)
-  return(data.frame(results))
+  results <- limer::call_limer(method = "list_participants", params = params)
+  results <- jsonlite::flatten(results)
+  names(results) <- sub("^participant_info\\.(firstname|lastname|email)$", "\\1", names(results))
+
+  return(results)
 }


### PR DESCRIPTION
- set default values for arguments except iSurveyID : returns all participants without attributes and conditions
- flatten participant columns
- rename these colmuns to `firstname`, `lastname` and `email`