### PR TITLE
fix a potential security risk

### DIFF
--- a/R/call_limer.R
+++ b/R/call_limer.R
@@ -36,5 +36,5 @@ call_limer <- function(method, params = list(), ...) {
   r <- httr::POST(getOption('lime_api'), httr::content_type_json(),
             body = jsonlite::toJSON(body.json, auto_unbox = TRUE), ...)
 
-  return(jsonlite::fromJSON(httr::content(r, as='text', encoding="utf-8"))$result)   # incorporated fix by petrbouchal
+  return(jsonlite::parse_json(httr::content(r, as='text', encoding="utf-8"))$result)   # incorporated fix by petrbouchal
 }


### PR DESCRIPTION
This a proposal only, but `jsonlite::fromJSON`, by default, also supports URLs as arguments and will then fetch these parsing the result instead of parsing its argument. If some limesurvey server would somehow be tricked in delivering a URL here, this could set also the API clients on risk, e.g. using CSRF.