### PR TITLE
get_session_key.R: fix PHP 8.1 major flaw

### DIFF
--- a/R/get_session_key.R
+++ b/R/get_session_key.R
@@ -14,7 +14,7 @@ get_session_key <- function(username = getOption('lime_username'),
                             password = getOption('lime_password')) {
   body.json = list(method = "get_session_key",
                    id = " ",
-                   params = list(admin = username,
+                   params = list(username = username,
                                  password = password))
 
     # Need to use jsonlite::toJSON because single elements are boxed in httr, which


### PR DESCRIPTION
TL;DR: param 'admin' for get_session_key succeeds in PHP 7.4, but fails in PHP 8.1. The param should be 'username'.

Limer sends 2 params for get_session_key: 'admin' and 'password'
```
body.json = list(method = "get_session_key",
                   id = " ",
                   params = list(admin = 'report',
                                 password = 'verysecret'))
```
https://github.com/cloudyr/limer/blob/master/R/get_session_key.R#L15-L18

Limesurvey expects params 'username' and 'password'
```
    /**
     * Set username and password by event
     *
     * @return null
     */
    public function remoteControlLogin()
    {
        $event = $this->getEvent();
        $this->setUsername($event->get('username'));
        $this->setPassword($event->get('password'));
    }
```
https://github.com/LimeSurvey/LimeSurvey/blob/971b1a72b5d3e62f299ef0a3829862f3d8ee5966/application/libraries/PluginManager/AuthPluginBase.php#L73-L83

I tested the fix in this PR against the same Limesurvey 5.3 instance, running PHP 7.4 and (symlinked) also PHP 8.1.13. See the comments under the commit: https://github.com/Jan-E/limer/commit/bc807c61fb834cb0034c376d814e80f126fc796c#commitcomment-94178825

Only afterwards I found that migliorati on the Limesurvey forum also suggested renaming 'admin' in 'username': https://forums.limesurvey.org/forum/installation-a-update-issues/127953-remotecontrol-doesn-t-work-after-update-to-5-3

Please review and merge.