### PR TITLE
Allow for selection of Auth Provider

### DIFF
--- a/R/get_session_key.R
+++ b/R/get_session_key.R
@@ -3,7 +3,7 @@
 #' This function logs into the LimeSurvey API and provides an access session key.
 #' @param username LimeSurvey username. Defaults to value set in \code{options()}.
 #' @param password LimeSurvey password Defaults to value set in \code{options()}.
-#' @param plugn LimeSurvey Auth Plugin Defaults to value set in \code{options() - if no value set uses Authdb}.
+#' @param auth LimeSurvey Auth Plugin Defaults to value set in \code{options() - if no value set uses Authdb}.
 #' @return API token
 #' @import httr
 #' @export

--- a/R/get_session_key.R
+++ b/R/get_session_key.R
@@ -3,6 +3,7 @@
 #' This function logs into the LimeSurvey API and provides an access session key.
 #' @param username LimeSurvey username. Defaults to value set in \code{options()}.
 #' @param password LimeSurvey password Defaults to value set in \code{options()}.
+#' @param plugn LimeSurvey Auth Plugin Defaults to value set in \code{options() - if no value set uses Authdb}.
 #' @return API token
 #' @import httr
 #' @export
@@ -11,11 +12,13 @@
 #' }
 
 get_session_key <- function(username = getOption('lime_username'),
-                            password = getOption('lime_password')) {
+                            password = getOption('lime_password'),
+                            plugin = getOption('lime_auth',default='Authdb')) {
   body.json = list(method = "get_session_key",
                    id = " ",
                    params = list(username = username,
-                                 password = password))
+                                 password = password,
+                                 plugin = plugin))
 
     # Need to use jsonlite::toJSON because single elements are boxed in httr, which
   # is goofy. toJSON can turn off the boxing automatically, though it's not

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Load your API details and user credentials into R using `options()`:
 options(lime_api = 'http://example.com/limesurvey/admin/remotecontrol')
 options(lime_username = 'put_username_here')
 options(lime_password = 'put_password_here')
+options(lime_auth = 'AuthLDAP')
 ```
+lime_auth is an optional parameter. If you do not set it, it will default to 'Authdb', which is the standard way of authentication in LimeSurvey. But if the LimeSurvey installation is set to use LDAP for authentication (as in many Universities), set it to 'AuthLDAP'.
 
 Before calling the API, you need to generate an access token with `get_session_key()` (examples of how to do this are shown below). Many services provide tokens that last indefinitely, but by default LimeSurvey's will only last for two hours. (this can be modified by editing `limesurvey/application/config/config-default.php` and changing `$config['iSessionExpirationTime'] = 7200;` to something else). 
 
@@ -32,6 +34,7 @@ library(limer)
 options(lime_api = 'http://example.com/limesurvey/admin/remotecontrol')
 options(lime_username = 'put_username_here')
 options(lime_password = 'put_password_here')
+options(lime_auth = 'AuthLDAP')
 
 # Do stuff with LimeSurvey API
 get_session_key()  # Log in


### PR DESCRIPTION
I am working with a university installation of Limer that uses LDAP authorization rather then Authdb. Since v3.2 the Limer API allows for selection of authentication plugin (see https://www.limesurvey.org/manual/RemoteControl_2_API#Security). However, the Limer package did not support setting this parameter until this pull request... Default value remains the current way ('Authdb')...